### PR TITLE
Redo modmenu parent

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,6 +29,8 @@
     "carpet": ">=1.4.27"
   },
   "custom": {
-    "modmenu:parent": "carpet"
+    "modmenu": {
+      "parent": "carpet"
+    }
   }
 }


### PR DESCRIPTION
Stops log spam of `[main/WARN]: WARNING! Mod minitweaks is only using deprecated 'modmenu:parent' custom value! This will be removed in 1.18 snapshots, so ask the author of this mod to support the new API.`